### PR TITLE
Add Sentry integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ nose
 gunicorn
 six
 pytest-cov==2.4.0
+raven==6.4.0

--- a/schema_collector/__init__.py
+++ b/schema_collector/__init__.py
@@ -1,0 +1,14 @@
+import logging
+
+from raven import Client
+from raven.conf import setup_logging
+from raven.handlers.logging import SentryHandler
+
+from . import settings
+
+
+# Configure Raven to capture warning logs
+raven_client = Client(settings.SENTRY_DSN)
+handler = SentryHandler(raven_client)
+handler.setLevel(logging.WARNING)
+setup_logging(handler)

--- a/schema_collector/app.py
+++ b/schema_collector/app.py
@@ -11,6 +11,8 @@ from venom.rpc.reflect.service import ReflectService
 from venom.rpc.reflect.stubs import OpenAPISchema, InfoMessage, ReflectStub, \
     TagMessage
 
+from .middleware import raven_middleware
+
 
 def collect_schemas(current, *schemas):
     return OpenAPISchema(
@@ -79,7 +81,7 @@ venom = Venom()
 venom.add(SchemaCollectorService)
 venom.add(ReflectService)
 
-app = create_app(venom)
+app = create_app(venom, web.Application(middlewares=[raven_middleware]))
 
 # Configure default CORS settings.
 cors = aiohttp_cors.setup(app, defaults={

--- a/schema_collector/middleware.py
+++ b/schema_collector/middleware.py
@@ -1,0 +1,12 @@
+from . import raven_client
+
+
+async def raven_middleware(app, handler):
+    """aiohttp middleware which captures any uncaught exceptions to Sentry before re-raising"""
+    async def middleware_handler(request):
+        try:
+            return await handler(request)
+        except Exception:
+            raven_client.captureException()
+            raise
+    return middleware_handler

--- a/schema_collector/settings.py
+++ b/schema_collector/settings.py
@@ -1,0 +1,3 @@
+import os
+
+SENTRY_DSN = os.environ.get('SENTRY_DSN', '')


### PR DESCRIPTION
Adds Raven to capture error events to Sentry

- aiohttp middleware logs uncaught exceptions, and re-raises
- log events of `warning` or higher level